### PR TITLE
Revert "Bump hexpm/elixir from 1.15.7-erlang-26.1-debian-buster-20230612-slim to 1.15.7-erlang-26.2-debian-bookworm-20231009-slim"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.15.7-erlang-26.2-debian-bookworm-20231009-slim as builder
+FROM hexpm/elixir:1.15.7-erlang-26.1-debian-buster-20230612-slim as builder
 
 # install build dependencies
 RUN apt-get update && apt-get install -y curl


### PR DESCRIPTION
Reverts Flo0807/share-a-secret#42