### PR TITLE
Replace Alpine.js with LiveView clipboard hook

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,12 +24,8 @@ import { Socket } from 'phoenix'
 import { LiveSocket } from 'phoenix_live_view'
 import { hooks as colocatedHooks } from 'phoenix-colocated/share_secret'
 import topbar from 'topbar'
-import Alpine from 'alpinejs'
 import { themeChange } from 'theme-change'
 import * as Hooks from './hooks/index'
-
-window.Alpine = Alpine
-Alpine.start()
 
 themeChange()
 
@@ -37,13 +33,6 @@ const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute
 const liveSocket = new LiveSocket('/live', Socket, {
   longPollFallbackMs: 2500,
   params: { _csrf_token: csrfToken },
-  dom: {
-    onBeforeElUpdated (from, to) {
-      if (from._x_dataStack) {
-        window.Alpine.clone(from, to)
-      }
-    }
-  },
   hooks: { ...Hooks, ...colocatedHooks }
 })
 

--- a/assets/js/hooks/copyToClipboard.js
+++ b/assets/js/hooks/copyToClipboard.js
@@ -1,0 +1,38 @@
+const copyEvent = 'share-secret:copy-to-clipboard'
+
+export default {
+  mounted () {
+    this.copying = false
+
+    this.handleCopy = async event => {
+      if (this.copying) return
+
+      const source = document.getElementById(event.detail.sourceId)
+
+      if (!source || !navigator.clipboard) return
+
+      this.copying = true
+
+      try {
+        await navigator.clipboard.writeText(source.value)
+        this.js().exec(this.el.dataset.copySuccess)
+
+        this.resetTimer = window.setTimeout(() => {
+          this.js().exec(this.el.dataset.copyReset)
+          this.copying = false
+          this.resetTimer = undefined
+        }, Number.parseInt(this.el.dataset.copyDuration, 10))
+      } catch (error) {
+        this.copying = false
+        console.error('Unable to copy to clipboard', error)
+      }
+    }
+
+    this.el.addEventListener(copyEvent, this.handleCopy)
+  },
+
+  destroyed () {
+    this.el.removeEventListener(copyEvent, this.handleCopy)
+    window.clearTimeout(this.resetTimer)
+  }
+}

--- a/assets/js/hooks/index.js
+++ b/assets/js/hooks/index.js
@@ -1,1 +1,2 @@
+export { default as CopyToClipboard } from './copyToClipboard'
 export { default as DynamicTextArea } from './dynamicTextArea'

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -5,7 +5,6 @@
   "packages": {
     "": {
       "dependencies": {
-        "alpinejs": "^3.14.1",
         "phoenix": "../deps/phoenix",
         "phoenix_html": "../deps/phoenix_html",
         "phoenix_live_view": "../deps/phoenix_live_view",
@@ -231,21 +230,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/@vue/reactivity": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.41.tgz",
-      "integrity": "sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/shared": "3.5.41"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.5.41",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.41.tgz",
-      "integrity": "sha512-IOnwSCma8j+9xJT6b8H0dEYidC80NsYmNMlZxRsukYcSoGaDBohog5hDxzeUXdFeGWFA++vWvxqOmrr96VlqMA==",
-      "license": "MIT"
-    },
     "node_modules/acorn": {
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
@@ -284,15 +268,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/alpinejs": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.16.2.tgz",
-      "integrity": "sha512-6kbqqrRK7iGPYx5upTfqc8Tcl1xhpcurLCxTdn4/ym2Kb68+cYj+2I5Zji53vUIPf7zj3C1DoIvrDkgrNDCXdA==",
-      "license": "MIT",
-      "dependencies": {
-        "@vue/reactivity": "~3.5.40"
       }
     },
     "node_modules/ansi-regex": {

--- a/assets/package.json
+++ b/assets/package.json
@@ -4,7 +4,6 @@
     "format:standard": "standard --fix"
   },
   "dependencies": {
-    "alpinejs": "^3.14.1",
     "phoenix": "../deps/phoenix",
     "phoenix_html": "../deps/phoenix_html",
     "phoenix_live_view": "../deps/phoenix_live_view",

--- a/lib/share_secret_web/components/core_components.ex
+++ b/lib/share_secret_web/components/core_components.ex
@@ -208,6 +208,7 @@ defmodule ShareSecretWeb.CoreComponents do
 
       <div class="tooltip" data-tip={gettext("Copy")}>
         <.copy_to_clipboard
+          id={"copy-#{@id}"}
           class="btn btn-neutral"
           aria-label={gettext("Copy %{id}", %{id: @id})}
           clipboard_element_id={@id}
@@ -443,6 +444,8 @@ defmodule ShareSecretWeb.CoreComponents do
     """
   end
 
+  attr :id, :string, required: true, doc: "the unique id of the copy button"
+
   attr :clipboard_element_id, :string,
     required: true,
     doc: "the element id of the clipboard element"
@@ -461,30 +464,42 @@ defmodule ShareSecretWeb.CoreComponents do
   def copy_to_clipboard(assigns) do
     ~H"""
     <button
-      x-data={"{
-        copyNotification: false,
-        copyToClipboard(id) {
-            value = document.getElementById(id).value
-            navigator.clipboard.writeText(value);
-            this.copyNotification = true;
-            let that = this;
-            setTimeout(function(){
-                that.copyNotification = false;
-            }, #{@animation_duration});
-        }
-      }"}
-      @click={"!copyNotification && copyToClipboard('#{@clipboard_element_id}');"}
+      id={@id}
+      type="button"
+      phx-hook="CopyToClipboard"
+      phx-click={
+        JS.dispatch("share-secret:copy-to-clipboard",
+          detail: %{sourceId: @clipboard_element_id}
+        )
+      }
+      data-copy-success={show_copy_notification(@id)}
+      data-copy-reset={hide_copy_notification(@id)}
+      data-copy-duration={@animation_duration}
       class={@class}
       {@rest}
     >
-      <span x-show="!copyNotification">
+      <span id={"#{@id}-idle"}>
         {render_slot(@idle)}
       </span>
-      <span x-show="copyNotification" x-cloak>
+      <span id={"#{@id}-active"} class="hidden" aria-live="polite">
         {render_slot(@active)}
       </span>
     </button>
     """
+  end
+
+  defp show_copy_notification(id) do
+    %JS{}
+    |> JS.hide(to: "##{id}-idle")
+    |> JS.show(to: "##{id}-active", display: "inline")
+    |> JS.set_attribute({"disabled", "disabled"}, to: "##{id}")
+  end
+
+  defp hide_copy_notification(id) do
+    %JS{}
+    |> JS.hide(to: "##{id}-active")
+    |> JS.show(to: "##{id}-idle", display: "inline")
+    |> JS.remove_attribute("disabled", to: "##{id}")
   end
 
   ## JS Commands

--- a/lib/share_secret_web/live/home_live/show.html.heex
+++ b/lib/share_secret_web/live/home_live/show.html.heex
@@ -26,6 +26,7 @@
       ><%= @secret %></textarea>
       <.copy_to_clipboard
         :if={@secret}
+        id="copy-secret"
         class="btn btn-neutral mt-6"
         aria-label={gettext("Copy secret")}
         clipboard_element_id="secret-text"

--- a/test/share_secret_web/browser/clipboard_test.exs
+++ b/test/share_secret_web/browser/clipboard_test.exs
@@ -1,0 +1,124 @@
+defmodule ShareSecretWeb.Browser.ClipboardTest do
+  use PhoenixTest.Playwright.Case, async: false
+  use ShareSecretWeb, :verified_routes
+
+  import Mox
+
+  alias PlaywrightEx.Frame
+  alias ShareSecret.CryptoMock
+
+  @timeout Application.compile_env(:phoenix_test, [:playwright, :timeout], 5_000)
+
+  @moduletag :playwright
+
+  setup :verify_on_exit!
+  setup :set_mox_global
+
+  test "copies generated links and revealed secrets", %{conn: conn} do
+    secret_text = "This is my super secret message!"
+    encryption_key = "test_encryption_key_123"
+    encrypted_secret = "encrypted_" <> secret_text
+
+    expect(CryptoMock, :generate_key, fn -> encryption_key end)
+    expect(CryptoMock, :encrypt, fn ^secret_text, ^encryption_key -> encrypted_secret end)
+    expect(CryptoMock, :decrypt!, fn ^encrypted_secret, ^encryption_key -> secret_text end)
+
+    session =
+      conn
+      |> visit(~p"/")
+      |> fill_in("Enter your secret", with: secret_text)
+      |> click_button("Generate links")
+      |> assert_has("#copy-link-0")
+
+    secret_link = element_value(session, "#link-0")
+
+    session
+    |> install_clipboard_mock()
+    |> set_copy_duration("#copy-link-0", 2_000)
+    |> click("#copy-link-0")
+    |> assert_has("#copy-link-0-active")
+
+    assert copied_text(session) == secret_link
+    assert {:ok, _} = wait_for_copy_reset(session, "#copy-link-0")
+    assert_has(session, "#copy-link-0-idle")
+
+    session =
+      conn
+      |> visit(secret_link)
+      |> click_button("Reveal")
+      |> assert_has("#copy-secret")
+
+    session
+    |> install_clipboard_mock()
+    |> click("#copy-secret")
+    |> assert_has("#copy-secret-active")
+
+    assert copied_text(session) == secret_text
+  end
+
+  defp install_clipboard_mock(session) do
+    {:ok, _} =
+      Frame.evaluate(session.frame_id,
+        expression: """
+        () => {
+          window.copiedText = null
+          Object.defineProperty(navigator, "clipboard", {
+            configurable: true,
+            value: {
+              writeText: async text => { window.copiedText = text }
+            }
+          })
+        }
+        """,
+        is_function: true,
+        timeout: @timeout
+      )
+
+    session
+  end
+
+  defp set_copy_duration(session, selector, duration) do
+    {:ok, _} =
+      Frame.evaluate(session.frame_id,
+        expression:
+          "([selector, duration]) => { document.querySelector(selector).dataset.copyDuration = duration }",
+        is_function: true,
+        arg: [selector, duration],
+        timeout: @timeout
+      )
+
+    session
+  end
+
+  defp copied_text(session) do
+    {:ok, text} =
+      Frame.evaluate(session.frame_id,
+        expression: "() => window.copiedText",
+        is_function: true,
+        timeout: @timeout
+      )
+
+    text
+  end
+
+  defp element_value(session, selector) do
+    {:ok, value} =
+      Frame.evaluate(session.frame_id,
+        expression: "selector => document.querySelector(selector).value",
+        is_function: true,
+        arg: selector,
+        timeout: @timeout
+      )
+
+    value
+  end
+
+  defp wait_for_copy_reset(session, selector) do
+    Frame.wait_for_function(session.frame_id,
+      expression: "selector => !document.querySelector(selector).disabled",
+      is_function: true,
+      arg: selector,
+      timeout: @timeout
+    )
+  end
+end


### PR DESCRIPTION
## Summary

- remove Alpine.js and its LiveView DOM patch bridge
- replace clipboard behavior with Phoenix.LiveView.JS commands and a scoped LiveView hook
- keep the copy success/reset interaction and handle clipboard failures without showing false success
- add Playwright coverage for generated-link and revealed-secret copying

## Testing

- mise exec -- mix precommit
- npm run lint:standard
- mise exec -- mix assets.build
- mise exec -- mix test --warnings-as-errors --only playwright